### PR TITLE
Windows basic support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,21 +5,17 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-include(${CMAKE_SOURCE_DIR}/conan.cmake)
-
-if (DEFINED ENV{CMAKE_PREFIX_PATH})
-    message(STATUS "Getting Qt from the system. CMAKE_PREFIX_PATH = $ENV{CMAKE_PREFIX_PATH}")
-    set(NEEDED_CONAN_DEPENDENCIES gflags/2.2.2@bincrafters/stable)
-else ()
-    message(STATUS "To use the Qt from your system, set the CMAKE_PREFIX_PATH env var")
-    message(STATUS "Trying to get Qt from Conan")
-    message(STATUS "If it fails try: 'conan remote add bincrafters \"https://api.bintray.com/conan/bincrafters/public-conan\"'")
-    set(NEEDED_CONAN_DEPENDENCIES gflags/2.2.2@bincrafters/stable qt/5.12.6@bincrafters/stable)
-endif ()
-
-conan_cmake_run(REQUIRES ${NEEDED_CONAN_DEPENDENCIES} BASIC_SETUP BUILD missing)
-
 set(CMAKE_CPP_STANDARD 17)
+
+if(EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup(TARGETS)
+    # So it gets the same interface than with the system find_package one
+    add_library(gflags::gflags INTERFACE IMPORTED)
+    target_link_libraries(gflags::gflags INTERFACE CONAN_PKG::gflags)
+else()
+    find_package(gflags REQUIRED)
+endif()
 
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
 find_package(Qt5Test REQUIRED)
@@ -37,7 +33,7 @@ find_package(OpenGL REQUIRED)
 # TODO(patricia-gallardo): Fix all of these
 if (MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-    set(EXTRA_WARNINGS /WX) # -Werror
+    #set(EXTRA_WARNINGS /WX) # -Werror
     # /wd4244 disables warings around conversion to or from 'long double', possible loss of data
     set(TEMPORARILY_DISABLED_WARNINGS /wd4244)
 else ()
@@ -68,9 +64,9 @@ add_executable(HeapVizGL
         vertex.cpp)
 
 target_link_libraries(HeapVizGL
-        ${CONAN_LIBS}
         OpenGL::GL
-        Qt5::Widgets)
+        Qt5::Widgets
+        gflags::gflags)
 
 target_compile_options(HeapVizGL PRIVATE
         ${EXTRA_WARNINGS}

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,25 @@
+# These packages require bincrafters repo:
+# conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+# mkdir build && cd build
+# For some reason there is a binary missing of sqlite3 in Windows. I have reported it, in the meantime it is necessary to build it from sources
+# conan install .. --build=missing
+# cmake .. -G "Visual Studio 15 Win64"
+# cmake --build . --config Release
+# cd bin
+# HeapVizGL.exe
+# > qt.qpa.plugin: Could not find the Qt platform plugin "windows" in ""
+# > This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
+# HeapVizGLTest.exe
+# > works...
+# > Totals: 7 passed, 3 failed, 0 skipped, 0 blacklisted, 3ms
+# > ********* Finished testing of TestDisplayHeapWindow *********
+
+[requires]
+gflags/2.2.2@bincrafters/stable
+qt/5.12.6@bincrafters/stable
+
+[generators]
+cmake
+
+[imports]
+bin, * -> bin


### PR DESCRIPTION
Hi @patricia-gallardo 

I have investigated and made this progress so far:

- I am using the explicit call to Conan client, to simplify a bit and not using the ``conan.cmake`` wrapper at this point to remove a moving piece and make errors more explicit when something fails.
- I have made it to work on Windows, written a conanfile.txt with some comments as a guide
- The Qt recipe is in the bincrafters repo, it is using a xxxConfig.cmake that is inside its package. It is in the process right now of being modularized (extracting its bundled dependencies to use Conan packages). You can see the dependency graph with ``conan info .. --graph=file.html`` inside the ``build`` folder. It is ongoing work, so changes are expected.
- I am created a ``add_library(gflags::gflags INTERFACE IMPORTED)`` gflags library to be able to provide the same interface if using or not using conan (assuming the system ``find_package(gflags)`` returns a ``gflags::gflags`` target, I haven't tested it.
- I needed to disable the Werror, it was failing in the build otherwise (``#set(EXTRA_WARNINGS /WX) # -Werror``)
- Note the ``imports`` section in the conanfile.txt to copy the DLLs, for execution. It is copying other things too, could be optimized. Note that the output directory has been defined as ``bin``, instead of ``Release`` or ``Debug`` in Windows, so changing configuration Debug/Release, would need to call the process from ``conan install .. -s build_type=Debug``.
- I managed to execute the Test application, but not the ``HeapVizGL``, it complains about Qt plugin not found.


cc @ericLemanissier
