### PR TITLE
seems to work in windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ else ()
     set(PROJECT_CONAN_FILE conanfile_qt.txt)
 endif ()
 
-conan_cmake_run(CONANFILE ${PROJECT_CONAN_FILE} BASIC_SETUP BUILD missing)
+conan_cmake_run(CONANFILE ${PROJECT_CONAN_FILE} BASIC_SETUP CMAKE_TARGETS BUILD missing)
 
 if (QT_GENERATOR)
     # Copy the qt.conf file to be next to the binary
@@ -54,7 +54,7 @@ find_package(OpenGL REQUIRED)
 # TODO(patricia-gallardo): Fix all of these
 if (MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-    set(EXTRA_WARNINGS /WX) # -Werror
+    #set(EXTRA_WARNINGS /WX) # -Werror
     # /wd4244 disables warings around conversion to or from 'long double', possible loss of data
     set(TEMPORARILY_DISABLED_WARNINGS /wd4244)
 else ()
@@ -86,7 +86,7 @@ set(COMMON_FILES
 add_executable(HeapVizGL ${COMMON_FILES} main.cpp)
 
 target_link_libraries(HeapVizGL
-        ${CONAN_LIBS}
+        CONAN_PKG::gflags
         OpenGL::GL
         Qt5::Widgets)
 

--- a/conanfile_qt.txt
+++ b/conanfile_qt.txt
@@ -10,3 +10,4 @@ qt/5.12.6@bincrafters/stable
 [options]
 
 [imports]
+bin, * -> bin


### PR DESCRIPTION
Let me suggest the following changes:

- Using CMAKE_TARGETS to let conan configure targets, so later it can use ``CONAN_PKG::gflags``, instead of linking with the global CONAN_LIBS that will contain all dependencies.
- I had to remove the Werror again, otherwise my build doesn't pass (VS 15)
- Added ``bin, * -> bin`` to imports

I am not using the virtualenv, not sure if needed for something Qt specific, in most cases, it is not needed. I managed to make it work:

```bash
$ cmake .. -G "Visual Studio 15 Win64" -DCMAKE_BUILD_TYPE=Release
$ cmake --build . --config Release
$ cd bin
$ HeapVizGLTest.exe
```

The important piece here is that the Release and Debug builds cannot be done switching in the IDE directly, but require the above steps with the correct build type. The problem is that the Qt package is using a QtConfig.cmake module inside the package, instead of the automatically generated one. While the config.cmake inside the package is convenient, because it is generated by the build of Qt, it has some problems:
- It is difficult to manage the transitive dependencies. Conflicts in targets might occur.
- It cannot model different package variants. For example there could be 4 different packages (combinations of 32/64 archs and Debug/Release build types), and each one would have its own internal QtConfig.cmake. CMake does not provide anyway to find_package different modules in different paths for different variants of the package, this is a known limitation of CMake find_package functionality. 

This is the reason we are proposing generators like ``cmake_find_package_multi``, that will handle these things automatically. (cc @ericLemanissier)

The ``HeapVizGL.exe`` still fails to launch, because the qt plugin, need to investigate this.

Please let me know if this helps. 
